### PR TITLE
Bump FSL from 6.0.7.9 to 6.0.7.15

### DIFF
--- a/fsl.yml
+++ b/fsl.yml
@@ -3,15 +3,15 @@ channels:
   - https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/public/
   - conda-forge
 dependencies:
-  # From manifest.json for 6.0.7.9
-  - fsl-bet2=2111.7
+  # From manifest.json for 6.0.7.15
+  - fsl-bet2=2111.8
   - fsl-flirt=2111.2
   - fsl-fast4=2111.3
   - fsl-fugue=2201.4
-  - fsl-mcflirt 2111.0
+  - fsl-mcflirt=2111.0
   - fsl-miscmaths=2203.2
-  - fsl-mist=2111.5
-  - fsl-topup=2203.2
+  - fsl-mist=2111.6
+  - fsl-topup=2203.5
   - fsl-eddy=2401.2
   - fsl-eddy_qc=v1.2.3
   - fsl-eddy-cuda-10.2=2401.2


### PR DESCRIPTION
Closes #15

Updates were searched for with the following script

```bash
# sed because mcflirt currently missing "="
mapfile -t pinned < <(sed 's/mcflirt 2111.0/mcflirt=2111.0/' env.yml | grep fsl- )
# some packages have "v" before version numbers (e.g., fsl-eddy_qc)
version_pattern="v*[0-9]+\.[0-9]*\.*[0-9]*$"
for fsl_version in 6.0.7.10 6.0.7.11 6.0.7.12 6.0.7.13 6.0.7.14 6.0.7.15; do
    echo "checking FSL ${fsl_version}"
    manifest=$(curl https://git.fmrib.ox.ac.uk/fsl/conda/manifest/-/raw/"${fsl_version}"/fsl-release.yml\?ref_type\=tags 2>/dev/null)    
    for pin in "${pinned[@]}"; do
        package_name=$(echo "${pin}" | grep -oE "fsl-[a-z0-9_\-]+" )
        if [[ $pin =~ fsl-eddy-cuda-10.2 ]]; then
            package_name=fsl-eddy-cuda-10.2
        fi
        if [[ $manifest =~ $package_name ]]; then
            manifest_version=$(echo "${manifest}" | grep -oE "${package_name} ${version_pattern}" | grep -oE "${version_pattern}")
            manifest_package_w_version=$(printf "%s=%s" "${package_name}" "${manifest_version}")
            if [[ ! "${pin}" =~ ${manifest_package_w_version} ]]; then
                printf "env has %s but FSL %s has %s\n" "${pin}" "${fsl_version}" "${manifest_package_w_version}"
            fi
        fi
    done
done

checking FSL 6.0.7.10
checking FSL 6.0.7.11
checking FSL 6.0.7.12
env has   - fsl-bet2=2111.7 but FSL 6.0.7.12 has fsl-bet2=2111.8
env has   - fsl-topup=2203.2 but FSL 6.0.7.12 has fsl-topup=2203.4
checking FSL 6.0.7.13
env has   - fsl-bet2=2111.7 but FSL 6.0.7.13 has fsl-bet2=2111.8
env has   - fsl-mist=2111.5 but FSL 6.0.7.13 has fsl-mist=2111.6
env has   - fsl-topup=2203.2 but FSL 6.0.7.13 has fsl-topup=2203.5
checking FSL 6.0.7.14
env has   - fsl-bet2=2111.7 but FSL 6.0.7.14 has fsl-bet2=2111.8
env has   - fsl-mist=2111.5 but FSL 6.0.7.14 has fsl-mist=2111.6
env has   - fsl-topup=2203.2 but FSL 6.0.7.14 has fsl-topup=2203.5
checking FSL 6.0.7.15
env has   - fsl-bet2=2111.7 but FSL 6.0.7.15 has fsl-bet2=2111.8
env has   - fsl-mist=2111.5 but FSL 6.0.7.15 has fsl-mist=2111.6
env has   - fsl-topup=2203.2 but FSL 6.0.7.15 has fsl-topup=2203.5
```