### PR TITLE
Update Ubuntu base and Cuda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM pennlinc/qsiprep-dsistudio:${TAG_DSISTUDIO} as build_dsistudio
 FROM pennlinc/qsiprep-micromamba:${TAG_MICROMAMBA} as build_micromamba
 FROM pennlinc/qsiprep-afni:${TAG_AFNI} as build_afni
 FROM pennlinc/qsiprep-drbuddi:${TAG_TORTOISE} as build_tortoise
-FROM pennlinc/qsiprep-drbuddicuda:${TAG_TORTOISE} as build_tortoisecuda
+FROM pennlinc/qsiprep-drbuddicuda:${TAG_TORTOISECUDA} as build_tortoisecuda
 FROM pennlinc/qsiprep-synb0:${TAG_SYNB0} as build_synb0
 FROM pennlinc/atlaspack:0.1.0 as atlaspack
 FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04 as ubuntu

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,7 @@ ENV ANTSPATH="/opt/ants/bin" \
     ANTS_DEPS="zlib1g-dev"
 
 ## DSI Studio
-ENV LD_LIBRARY_PATH="$QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH" \
-    PKG_CONFIG_PATH="$QT_BASE_DIR/lib/pkgconfig:$PKG_CONFIG_PATH" \
-    PATH="$QT_BASE_DIR/bin:$PATH:/opt/dsi-studio-cpu/dsi_studio" \
+ENV PATH="$PATH:/opt/dsi-studio-cpu" \
     DSI_STUDIO_DEPS="qt6-base-dev libqt6charts6-dev"
 
 ## MRtrix3
@@ -193,7 +191,7 @@ RUN apt-get update \
     && apt install -y --no-install-recommends \
     ${DSI_STUDIO_DEPS} ${MRTRIX3_DEPS} ${TORTOISE_DEPS} wget git binutils \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-COPY --from=build_dsistudio /opt/dsi-studio-cpu/dsi_studio /opt/dsi-studio-cpu/dsi_studio
+COPY --from=build_dsistudio /opt/dsi-studio-cpu /opt/dsi-studio-cpu
 
 # Install gcc-9
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
@@ -220,10 +218,6 @@ ENV \
     IS_DOCKER_8395080871=1 \
     ARTHOME="/opt/art" \
     DIPY_HOME=/home/qsiprep/.dipy \
-    QTDIR=$QT_BASE_DIR \
-    PATH=$QT_BASE_DIR/bin:$PATH \
-    LD_LIBRARY_PATH=$QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH \
-    PKG_CONFIG_PATH=$QT_BASE_DIR/lib/pkgconfig:$PKG_CONFIG_PATH \
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/conda/envs/qsiprep/lib/python3.10/site-packages/nvidia/cudnn/lib:/opt/freesurfer/lib
 
 WORKDIR /root/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM pennlinc/qsiprep-drbuddi:${TAG_TORTOISE} as build_tortoise
 FROM pennlinc/qsiprep-drbuddicuda:${TAG_TORTOISE} as build_tortoisecuda
 FROM pennlinc/qsiprep-synb0:${TAG_SYNB0} as build_synb0
 FROM pennlinc/atlaspack:0.1.0 as atlaspack
-FROM nvidia/13.0.2-runtime-ubuntu22.04 as ubuntu
+FROM nvidia/12.2.2-runtime-ubuntu22.04 as ubuntu
 
 # Make a dummy fsl image containing no FSL
 FROM ubuntu as no_fsl

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM pennlinc/qsiprep-drbuddi:${TAG_TORTOISE} as build_tortoise
 FROM pennlinc/qsiprep-drbuddicuda:${TAG_TORTOISE} as build_tortoisecuda
 FROM pennlinc/qsiprep-synb0:${TAG_SYNB0} as build_synb0
 FROM pennlinc/atlaspack:0.1.0 as atlaspack
-FROM nvidia/cuda:11.1.1-runtime-ubuntu18.04 as ubuntu
+FROM nvidia/13.0.2-runtime-ubuntu22.04 as ubuntu
 
 # Make a dummy fsl image containing no FSL
 FROM ubuntu as no_fsl

--- a/Dockerfile_3Tissue
+++ b/Dockerfile_3Tissue
@@ -1,9 +1,9 @@
-FROM nvidia/cuda:11.1.1-devel-ubuntu18.04
+FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04
 ARG TAG_ANTS
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    curl git g++ python libeigen3-dev zlib1g-dev libqt5opengl5-dev libqt5svg5-dev libgl1-mesa-dev libfftw3-dev libtiff5-dev libpng-dev unzip
+    curl git g++ python3 python-is-python3 libeigen3-dev zlib1g-dev libqt6opengl6-dev libqt6svg6-dev libgl1-mesa-dev libfftw3-dev libtiff5-dev libpng-dev unzip
 
 ARG MRTRIX_SHA=5f4c31bc93008520c61d59b94af0db3f17b4ab76
 ENV PATH="/opt/mrtrix3-latest/bin:$PATH"

--- a/Dockerfile_AFNI
+++ b/Dockerfile_AFNI
@@ -1,4 +1,4 @@
-# Copied from: fMRIPrep Docker Container Image distribution
+# Copied and Modified from: fMRIPrep Docker Container Image distribution
 #
 # MIT License
 #
@@ -21,12 +21,13 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 ARG TAG_ANTS
 
 # AFNI latest (neurodocker build)
 RUN apt-get update -qq \
     && apt-get install -y -q --no-install-recommends \
+           ca-certificates \
            apt-utils \
            ed \
            gsl-bin \

--- a/Dockerfile_ANTs
+++ b/Dockerfile_ANTs
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.2.2-devel-ubuntu18.04 as base
+FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04 as base
 ARG TAG_ANTS
 FROM base as builder
 
@@ -11,7 +11,6 @@ RUN apt-get update && \
                     gnupg \
                     software-properties-common \
                     wget \
-                    ninja-build \
                     git \
                     g++ \
                     zlib1g-dev \
@@ -24,10 +23,12 @@ RUN apt-get update && \
 
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
     | apt-key add - \
-  && apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ bionic main' \
+  && apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' \
   && apt-get update \
-  && apt-get -y install cmake=3.23.2-0kitware1ubuntu18.04.1 cmake-data=3.23.2-0kitware1ubuntu18.04.1
+  && apt-get -y install cmake=3.30.2-0kitware1ubuntu22.04.1 \
+    cmake-data=3.30.2-0kitware1ubuntu22.04.1
 
+# Version 2.4.3 : last version using ITK 5.3
 ARG ANTS_SHA=caa60eb4ad53d561f9ddd72b71a6baf2acac0078
 RUN mkdir /tmp/ants \
     && cd /tmp \
@@ -40,8 +41,9 @@ RUN mkdir /tmp/ants \
     && mkdir -p /opt/ants \
     && git config --global url."https://".insteadOf git:// \
     && cmake \
-        -GNinja \
-        -DBUILD_TESTING=OFF \
+        -G "Unix Makefiles" \
+        -DBUILD_TESTING:BOOL=OFF \
+        -DBUILD_EXAMPLES:BOOL=OFF \
         -DCMAKE_C_COMPILER=/usr/bin/gcc-9 \
         -DCMAKE_CXX_COMPILER=/usr/bin/g++-9 \
         -DBUILD_SHARED_LIBS=ON \
@@ -49,9 +51,9 @@ RUN mkdir /tmp/ants \
         -DSuperBuild_ANTS_CXX_OPTIMIZATION_FLAGS="-mtune=x86-64 -march=x86-64" \
         -DCMAKE_INSTALL_PREFIX=/opt/ants \
         /tmp/ants/source \
-    && cmake --build . --parallel 1 \
+    && make -j 1 \
     && cd ANTS-build \
-    && cmake --install . \
+    && make install \
     && cd /opt/ants/bin \
     && rm \
         ANTSUseLandmarkImagesToGetAffineTransform \

--- a/Dockerfile_DSIStudio
+++ b/Dockerfile_DSIStudio
@@ -1,10 +1,9 @@
-FROM nvidia/cuda:11.2.2-devel-ubuntu18.04
+FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04
 ARG TAG_ANTS
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
 
 RUN apt update && apt full-upgrade -y && \
   apt install --no-install-recommends -y software-properties-common && \
-  add-apt-repository -y ppa:beineri/opt-qt-5.12.8-bionic && \
   add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
   apt install -y --no-install-recommends \
   unzip \
@@ -15,8 +14,8 @@ RUN apt update && apt full-upgrade -y && \
   libboost-all-dev \
   zlib1g-dev \
   ca-certificates \
-  qt512base \
-  qt512charts-no-lgpl \
+  qt6-base-dev \
+  libqt6charts6-dev \
   mesa-common-dev \
   libglu1-mesa-dev \
   build-essential \
@@ -31,47 +30,27 @@ RUN apt update && apt full-upgrade -y && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
   RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
-  | apt-key add - \
-&& apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ bionic main' \
-&& apt-get update \
-&& apt-get -y install cmake=3.23.2-0kitware1ubuntu18.04.1 cmake-data=3.23.2-0kitware1ubuntu18.04.1
-
+    | apt-key add - \
+  && apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' \
+  && apt-get update \
+  && apt-get -y install cmake=3.30.2-0kitware1ubuntu22.04.1 \
+    cmake-data=3.30.2-0kitware1ubuntu22.04.1
 #Need to use a different shell so the QT ENV script works
 SHELL ["/bin/bash", "-c"]
-ENV PATH="$PATH:/opt/qt512/bin"
 
-ARG DSI_SHA=03476a67bc96a1d0c90928001b5dd1c490539ee0
-ARG TIPL_SHA=ebd2d8b1ee13d6f87e78db62f2f1a1400b353898
+ARG DSI_DATE=2025.04.16
 
-RUN source /opt/qt512/bin/qt512-env.sh \
-  && mkdir /opt/dsi-studio \
-  && cd /opt/dsi-studio \
-  && curl -sSLO https://github.com/frankyeh/DSI-Studio/archive/${DSI_SHA}.zip \
-  && unzip ${DSI_SHA}.zip \
-  && mv DSI-Studio-${DSI_SHA} src \
-  && rm -rf ${DSI_SHA}.zip \
+ARG TIPL_SHA=1f89c676df1e3577fe524833d2e67063eebb24f3
+
+RUN cd /opt/ \
+  && curl -sSLO https://github.com/frankyeh/DSI-Studio/releases/download/${DSI_DATE}/dsi_studio_ubuntu2204_cpu.zip \
+  && unzip dsi_studio_ubuntu2204_cpu.zip \
+  && rm -rf dsi_studio_ubuntu2204_cpu.zip \
   && curl -sSLO https://github.com/frankyeh/TIPL/archive/${TIPL_SHA}.zip \
   && unzip ${TIPL_SHA}.zip \
-  && mv TIPL-${TIPL_SHA} src/TIPL \
+  && mv TIPL-${TIPL_SHA} dsi-studio-cpu/TIPL \
   && rm ${TIPL_SHA}.zip \
-  && mkdir build && cd build \
-  && qmake ../src && make -j 1
+  && chmod 755 dsi-studio-cpu/dsi_studio
 
-ARG ATLAS_SHA=bf5afab9b2405f076b1acdf4706c9688525eb713
-ARG UNET_SHA=2e839aae744883983974194dcf6aeff154a82197
+ENV PATH="$PATH:/opt/dsi-studio-cpu"
 
-RUN cd /opt/dsi-studio \
-  && mv build/dsi_studio . \
-  && chmod 755 dsi_studio \
-  && cp -R src/other/* . \
-  && rm -rf src build \
-  && curl -sSLO https://github.com/frankyeh/UNet-Studio-Data/archive/${UNET_SHA}.zip \
-  && unzip ${UNET_SHA}.zip \
-  && rm ${UNET_SHA}.zip \
-  && mv UNet-Studio-Data-${UNET_SHA}/network/ . \
-  && rm -rf mv UNet-Studio-Data-${UNET_SHA} \
-  && curl -sSLO https://github.com/frankyeh/DSI-Studio-atlas/archive/${ATLAS_SHA}.zip \
-  && unzip ${ATLAS_SHA}.zip \
-  && rm -rf DSI-Studio-atlas-${ATLAS_SHA}/.git \
-  && mv DSI-Studio-atlas-${ATLAS_SHA} atlas \
-  && rm ${ATLAS_SHA}.zip

--- a/Dockerfile_FSLconda
+++ b/Dockerfile_FSLconda
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.2.2-devel-ubuntu18.04
+FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04
 ARG TAG_ANTS
 
 RUN apt-get update && \

--- a/Dockerfile_FreeSurfer
+++ b/Dockerfile_FreeSurfer
@@ -1,5 +1,5 @@
 FROM freesurfer/freesurfer:7.3.1 AS freesurfer
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 ARG TAG_ANTS
 
 COPY --from=freesurfer \

--- a/Dockerfile_MRtrix3
+++ b/Dockerfile_MRtrix3
@@ -1,9 +1,9 @@
-FROM nvidia/cuda:11.2.2-devel-ubuntu18.04
+FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04
 ARG TAG_ANTS
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    curl git g++ python libeigen3-dev zlib1g-dev libqt5opengl5-dev libqt5svg5-dev libgl1-mesa-dev libfftw3-dev libtiff5-dev libpng-dev unzip
+    curl git g++ python3 python-is-python3 libeigen3-dev zlib1g-dev libqt6opengl6-dev libqt6svg6-dev libgl1-mesa-dev libfftw3-dev libtiff5-dev libpng-dev unzip
 
 ARG MRTRIX_SHA=670e7b0625572f8b1f13b2793bde506526985d55
 ENV PATH="/opt/mrtrix3-latest/bin:$PATH"

--- a/Dockerfile_Micromamba
+++ b/Dockerfile_Micromamba
@@ -1,4 +1,4 @@
-# Copied from: fMRIPrep Docker Container Image distribution
+# Copied and Modified from: fMRIPrep Docker Container Image distribution
 #
 # MIT License
 #
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM nvidia/cuda:11.2.2-devel-ubuntu18.04
+FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04
 ARG TAG_ANTS
 
 RUN apt-get update && \
@@ -55,7 +55,7 @@ COPY qsiprep_env.yml /tmp/env.yml
 
 WORKDIR /tmp
 RUN micromamba config set extract_threads 1
-RUN micromamba create -vv -y -f /tmp/env.yml
+RUN micromamba create -c conda-forge -vvv -y -f /tmp/env.yml
 ENV PATH=/opt/conda/envs/qsiprep/bin:$PATH
 RUN micromamba clean -y -a
 

--- a/Dockerfile_SynB0
+++ b/Dockerfile_SynB0
@@ -1,11 +1,11 @@
 FROM leonyichencai/synb0-disco:v3.1 AS synb0
-FROM ubuntu:18.04 AS base
+FROM ubuntu:22.04 AS base
 ARG TAG_ANTS
 
 FROM alpine AS builder
 RUN mkdir -p /opt/synb0 \
   && cd /opt/synb0 \
-  && wget https://raw.githubusercontent.com/MASILab/Synb0-DISCO/master/synb0-license-ccby4.0.txt
+  && wget https://raw.githubusercontent.com/MASILab/Synb0-DISCO/68f2ba1cae32e2499db585c3eb1b195db4dc2d96/synb0-license-ccby4.0.txt
 
 FROM base 
 # Get the SyNb0 models and python executables

--- a/Dockerfile_TORTOISE
+++ b/Dockerfile_TORTOISE
@@ -2,7 +2,7 @@ ARG TAG_ANTS
 
 FROM pennlinc/qsiprep-ants:${TAG_ANTS} as base
 FROM base as builder
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
 
 RUN apt update && apt full-upgrade -y && \
   apt install --no-install-recommends -y software-properties-common && \
@@ -17,26 +17,17 @@ RUN apt update && apt full-upgrade -y && \
 
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
     | apt-key add - \
-  && apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ bionic main' \
+  && apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' \
   && apt-get update \
-  && apt-get -y install cmake=3.23.2-0kitware1ubuntu18.04.1 cmake-data=3.23.2-0kitware1ubuntu18.04.1
+  && apt-get -y install cmake=3.30.2-0kitware1ubuntu22.04.1 \
+    cmake-data=3.30.2-0kitware1ubuntu22.04.1
 
+RUN apt install -y libboost-all-dev
 
+ARG TORTOISE_SHA=cea83b5bef845b54c079072f385a087768a60ded
 RUN \
   mkdir /src \
   && cd /src \
-  && wget https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.gz \
-  && tar -xvf boost_1_77_0.tar.gz \
-  && cd boost_1_77_0 \
-  && rm /usr/bin/g++ \
-  && ln -s /usr/bin/g++-9 /usr/bin/g++ \
-  && ./bootstrap.sh --with-libraries=iostreams,filesystem,system,regex --prefix=/usr/local/boost176 \
-  && ./b2 install
-
-
-ARG TORTOISE_SHA=5d0c688e85fd12a974d2ecbd8b567913a0b46c4f
-RUN \
-  cd /src \
   && git clone https://github.com/eurotomania/TORTOISEV4.git \
   && cd TORTOISEV4/TORTOISEV4 \
   && git checkout ${TORTOISE_SHA} \

--- a/Dockerfile_TORTOISEcuda
+++ b/Dockerfile_TORTOISEcuda
@@ -2,7 +2,7 @@ ARG TAG_ANTS
 
 FROM pennlinc/qsiprep-ants:${TAG_ANTS} as base
 FROM base as builder
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
 
 RUN apt update && apt full-upgrade -y && \
   apt install --no-install-recommends -y software-properties-common && \
@@ -17,26 +17,17 @@ RUN apt update && apt full-upgrade -y && \
 
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
     | apt-key add - \
-  && apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ bionic main' \
+  && apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ jammy main' \
   && apt-get update \
-  && apt-get -y install cmake=3.23.2-0kitware1ubuntu18.04.1 cmake-data=3.23.2-0kitware1ubuntu18.04.1
+  && apt-get -y install cmake=3.30.2-0kitware1ubuntu22.04.1 \
+    cmake-data=3.30.2-0kitware1ubuntu22.04.1
 
+RUN apt install -y libboost-all-dev
 
+ARG TORTOISE_SHA=cea83b5bef845b54c079072f385a087768a60ded
 RUN \
   mkdir /src \
   && cd /src \
-  && wget https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.gz \
-  && tar -xvf boost_1_77_0.tar.gz \
-  && rm /usr/bin/g++ \
-  && ln -s /usr/bin/g++-9 /usr/bin/g++ \
-  && cd boost_1_77_0 \
-  && ./bootstrap.sh --with-libraries=iostreams,filesystem,system,regex --prefix=/usr/local/boost176 \
-  && ./b2 install
-
-
-ARG TORTOISE_SHA=5d0c688e85fd12a974d2ecbd8b567913a0b46c4f
-RUN \
-  cd /src \
   && git clone https://github.com/eurotomania/TORTOISEV4.git \
   && cd TORTOISEV4/TORTOISEV4 \
   && git checkout ${TORTOISE_SHA} \

--- a/qsiprep_env.yml
+++ b/qsiprep_env.yml
@@ -4,16 +4,18 @@ channels:
 dependencies:
   - mkl
   - mkl-service
-  - numpy=1.23.5
-  - scipy=1.11
-  - fury
+  - numpy==1.26.4
+  - scipy==1.11.4
+  - vtk==9.3.1
   - pip
   - python=3.10
   - pip:
       - bids-validator==1.14.1
       - coverage
-      - dipy==1.8.0
-      - dmri-amico==1.5.4
+      - dipy==1.11.0
+      - dmri-amico==2.1.0
+      - dmri-dicelib==1.2.1
+      - fury==0.12.0
       - jinja2==3.0.3
       - keras==2.8.0
       - matplotlib==3.8.3
@@ -21,23 +23,21 @@ dependencies:
       - nilearn==0.10.1
       - nipype==1.8.6
       - niworkflows >=1.9,<= 1.10
-      - numpy==1.23.5
       - pandas==1.5.3
       - pillow==10.3.0
-      - pyafq==1.3.2
+      - pyafq==2.1
       - pytest==8.2.2
       - pytest-cov==5.0.0
       - pytest-env==1.1.3
       - protobuf==3.19.6
-      - scikit-image==0.22.0
-      - scikit-learn==1.4.0
+      - scikit-image==0.25.2
+      - scikit-learn==1.7.2
       - sentry-sdk==1.40.6
       - simpleitk==2.3.1
-      - spams==2.6.5.4
       - sqlalchemy==2.0.27
       - templateflow==23.1.0
       - tensorflow-gpu==2.8.4
       - torch==1.13.1
       - transforms3d==0.4.1
-      - trx-python==0.2.9
+      - trx-python==0.3
       - xvfbwrapper==0.2.9

--- a/setup_build.sh
+++ b/setup_build.sh
@@ -8,17 +8,17 @@ fi
 export BUILD_TAG
 
 # Versions of the components
-export TAG_FSL=24.4.24
-export TAG_FREESURFER=24.9.3
-export TAG_ANTS=24.4.24
-export TAG_MRTRIX3=24.4.24
-export TAG_3TISSUE=24.4.24
-export TAG_DSISTUDIO=24.7.4
-export TAG_MICROMAMBA=24.7.1
-export TAG_AFNI=23.3.2
-export TAG_TORTOISE=24.4.29
-export TAG_TORTOISECUDA=24.4.29
-export TAG_SYNB0=24.9.0
+export TAG_FSL=25.11.14
+export TAG_FREESURFER=25.11.14
+export TAG_ANTS=25.11.14
+export TAG_MRTRIX3=25.11.14
+export TAG_3TISSUE=25.11.14
+export TAG_DSISTUDIO=25.11.14
+export TAG_MICROMAMBA=25.11.14
+export TAG_AFNI=25.11.14
+export TAG_TORTOISE=25.11.14
+export TAG_TORTOISECUDA=25.11.14
+export TAG_SYNB0=25.11.14
 
 echo "Settings:"
 echo "----------"


### PR DESCRIPTION
Updates:
  - Cuda to 12.2.2
  - Ubuntu to 22.04

These changes necessitated updating other packages, so I took the liberty to update:
  - QT to 6
  - Python to 3
  - DSI Studio to latest
  - Amico to latest
  - pyAFQ to latest
  - Tortoise to 4.1
  - Prebuilt BOOST for tortoise

This may necessitate concomitant changes in qsiprep

This is first steps in resolving this issue:
https://github.com/PennLINC/qsiprep/issues/935 




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps all images to Ubuntu 22.04 with CUDA 12.2.2, migrates to Qt6, updates DSI Studio and key neuroimaging stacks (ANTs, TORTOISE), and refreshes the conda environment and build tags.
> 
> - **Base/Images**
>   - Upgrade all Dockerfiles to `ubuntu:22.04` with `CUDA 12.2.2`.
>   - Standardize Kitware repo to `jammy` and update `cmake`.
> - **DSI Studio / Qt**
>   - Migrate from Qt5 to **Qt6**; install `qt6-base-dev` and `libqt6charts6-dev`.
>   - Switch to prebuilt CPU package at `/opt/dsi-studio-cpu`; add to `PATH` and strip Qt ABI tags for Singularity.
> - **ANTs**
>   - Rebase build, pin to `ANTS 2.4.3`, switch to Makefiles, and update toolchain; copy pruned binaries.
> - **TORTOISE (CPU/CUDA)**
>   - Update build to use system `libboost-all-dev`; refresh `TORTOISE_SHA`; rebuild against updated ITK/CMake.
> - **MRtrix3 / 3Tissue**
>   - Move to Python 3 and Qt6 dev packages; rebuild from specified SHAs.
> - **AFNI**
>   - Rebase to `ubuntu:22.04` and adjust runtime deps.
> - **Micromamba / Conda env**
>   - Update micromamba creation flags and base; run AMICO setup.
>   - Refresh `qsiprep_env.yml`: bump `numpy/scipy`, add `vtk`, update `dipy`, `dmri-amico`, `pyafq`, `scikit-*`, `trx-python`, add `dmri-dicelib`, `fury`.
> - **SynB0**
>   - Rebase to `ubuntu:22.04`, pin license file to a specific commit, ensure `inference.py` is executable.
> - **Build orchestration**
>   - Update component tags in `setup_build.sh` to `25.11.14` and fix `TAG_TORTOISECUDA` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c949b12c36460499dc01c4a187e1142fc7a3f911. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->